### PR TITLE
カードのサムネイルのサイズがバラバラだったので、表示のアスペクト比を300x200に統一

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -200,6 +200,12 @@
   border-block-end: 0.25rem solid var(--color-main);
 }
 
+.p-card__thumbnail img {
+  aspect-ratio: 1.5;
+  -o-object-fit: cover;
+     object-fit: cover;
+}
+
 .c-card__title {
   font-size: 1.5rem;
   font-weight: 700;

--- a/sass/component/_c-card.scss
+++ b/sass/component/_c-card.scss
@@ -2,6 +2,10 @@
 }
 
 .p-card__thumbnail {
+  img {
+    aspect-ratio: calc(300 / 200);
+    object-fit: cover;
+  }
 }
 
 .c-card__title {


### PR DESCRIPTION
適用をお願いします。